### PR TITLE
Added js parser.

### DIFF
--- a/js-parser/css/style.css
+++ b/js-parser/css/style.css
@@ -1,0 +1,67 @@
+body {
+  margin: 0;
+  font-family: "Didact Gothic";
+}
+
+.wrapper {
+  max-width: 650px;
+  margin: 0 auto;
+  padding: 16px;
+}
+
+nav {
+  display: flex;
+  background: #555;
+  padding: 16px;
+  color: white;
+}
+
+nav > div{
+  min-width: 100px;
+}
+
+nav > div + div{
+  margin-left: 16px;
+}
+
+nav label{
+  display: block;
+}
+
+nav select {
+  width: 100%;
+}
+
+article > h1 {
+  font-size: 2.5em;
+}
+
+span[data-number]:before {
+  display: inline-block;
+  margin: 0 .3em 0 .5em;
+  content: attr(data-number);
+  font-weight: bold;
+  color: #aaa;
+}
+
+[data-variants] {
+  color: #2467a2;
+  border-bottom: 1px solid rgba(36, 103, 162, .2);
+  cursor: pointer;
+}
+
+.active-variant{
+  background: #ffffac;
+}
+
+.notes {
+  border-top: 1px solid #eee;
+  margin-top: 2em;
+  padding-top: 2em;
+  font-size: .875em;
+}
+
+.note-ms {
+  display: block;
+  font-weight: bold;
+}

--- a/js-parser/js-parser.html
+++ b/js-parser/js-parser.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html>
+  <head>
+    <title>OCP</title>
+    <link href="https://fonts.googleapis.com/css?family=Didact+Gothic&amp;subset=greek-ext" rel="stylesheet">
+    <link rel="stylesheet" href="css/style.css">
+  </head>
+  <body>
+    <nav>
+      <div>
+          <label>Book</label>
+          <select id="book-select">
+            <option>Select One</option>
+            <option value="1En_test_1.xml">1 Enoch</option>
+            <option value="ApocrEzek.xml">Apocryphon of Ezekiel</option>
+          </select>
+      </div>
+      <div>
+        <label>Version</label>
+        <select id="version-select"></select>
+      </div>
+      <div>
+        <label>Manuscript</label>
+        <select id="ms-select"></select>
+      </div>
+    </nav>
+    <main class="wrapper">
+      <article id="text"></article>
+      <footer class="notes"></footer>
+    </main>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script src="js/parser.js"></script>
+    <script src="js/nav.js"></script>
+    <script>
+        $(document).on('click', '[data-variants]', function(e){
+          e.preventDefault();
+          $('.active-variant').removeClass('active-variant');
+          $(this).addClass('active-variant');
+          var variants = $(this).data('variants');
+          var html = '';
+          for(var i = 0; i < variants.length; i++){
+            html += '<h3>Variant Readings</h3>';
+            html += '<span class="note-ms">' + variants[i].ms + '</span>';
+            html += '<span class="note-variant">' + variants[i].text + '</span>';
+          }
+          $('.notes').html(html);
+        });
+      </script>
+  </body>
+</html>

--- a/js-parser/js/nav.js
+++ b/js-parser/js/nav.js
@@ -1,0 +1,32 @@
+$(document).on('change', '#book-select', function(){
+  var versions = getBookInfo($(this).val(), function(versions){
+    var titleSelect = '';
+    var selected;
+    for(var t = 0; t < versions.length; t++){
+      selected = t === 0 ? ' selected' : '';
+      titleSelect += '<option' + selected +' data-mss="' + versions[t].mss.join(',') + '">' + versions[t].title + '</option>';
+    }
+    $('#version-select').html(titleSelect);
+    populateMsSelect(versions[0].mss);
+  });
+});
+
+$(document).on('change', '#version-select', function(){
+  var mss = $(this).find('option:selected').data('mss').split(',');
+  populateMsSelect(mss);
+});
+
+$(document).on('change', '#ms-select', function(){
+  getText($('#book-select').val(), $('#version-select').val(), $('#ms-select').val());
+});
+
+function populateMsSelect(mss){
+  var selectElHtml = '';
+  var selected;
+  for(var i = 0; i < mss.length; i++){
+    selected = i === 0 ? ' selected' : '';
+    selectElHtml += '<option' + selected +'>' + mss[i] + '</option>';
+  }
+  $('#ms-select').html(selectElHtml);
+  getText($('#book-select').val(), $('#version-select').val(), $('#ms-select').val());
+}

--- a/js-parser/js/parser.js
+++ b/js-parser/js/parser.js
@@ -1,0 +1,79 @@
+var ocp = {
+  html: '',
+  pathToTexts: '../test/docs/'
+};
+
+function getText(b, v, m){
+  window.location.hash = b.split('.')[0];
+  $('.notes').html('');
+  ocp.html = '';
+  ocp.ms = m;
+  $.get(ocp.pathToTexts + b, function(data){
+    xml = $.parseXML(data);
+    $xml = $(xml);
+    $xml.find('w').remove();
+    var title =  $xml.find('book').attr('title');
+    var divisions = [];
+    $xml.find('version').eq(0).find('divisions').find('division').each(function(){
+      divisions.push($(this).attr('label'));
+    });
+    $('#text').html('<h1>' + title + '</h1>' + getSections($xml.find('version[title="' + v + '"]').find('text'), divisions));
+  });
+}
+
+function getSections(container, divisions){
+  container.find('> [number]').each(function(){
+    if($(this).find('> [number]').length === 0){
+      ocp.html += getVerses($(this));
+    }else{
+      var level = $(this).parents('[number]').length;
+      ocp.html += '<section><h1>' + divisions[level] + ' ' + $(this).attr('number') + '</h1>';
+      getSections($(this), divisions);
+      ocp.html += '</section>';
+    }
+  });
+  return ocp.html;
+}
+
+function getVerses(verse){
+  var textHTML = '<span data-number="' + verse.attr('number') + '">';
+  verse.find('reading[mss*=" ' + ocp.ms + ' "], reading[mss^="' + ocp.ms + ' "]').each(function(){
+    var hasVariants = $(this).siblings().length > 0;
+    if(hasVariants){
+      var variants = '';
+      $(this).siblings().each(function(i){
+        if(i > 0){
+          variants += ',';
+        }
+        variants += '{"ms":"' + $.trim($(this).attr('mss')) + '", "text":"' + $.trim($(this).text()).replace(/'/g, '&apos;') + '"}';
+      });
+      textHTML += '<a data-variants=\'[' + variants + ']\'>';
+    }
+    textHTML += $(this).text();
+    if(hasVariants){
+        textHTML += '</a>';
+    }
+  });
+  textHTML += '</span>';
+  return textHTML;
+}
+
+function getBookInfo(book, cb){
+  $.get(ocp.pathToTexts + book, function(data){
+    xml = $.parseXML(data);
+    $xml = $(xml);
+    var versions = [];
+    $xml.find('version').each(function(){
+      var $this = $(this);
+      var mss = [];
+      var title = $this.attr('title');
+      var language = $this.attr('language');
+      $this.find('manuscripts').find('ms').each(function(){
+        mss.push($(this).attr('abbrev'));
+      });
+      versions.push({title: title, language: language, mss: mss});
+    });
+    cb(versions);
+  });
+
+}

--- a/test/docs/1En_test_1.xml
+++ b/test/docs/1En_test_1.xml
@@ -29,7 +29,7 @@
         </resource>
     </resources>
     <manuscripts>
-      <ms abbrev="p1" language="Ethiopic" show="yes">
+      <ms abbrev="p" language="Ethiopic" show="yes">
           <name>
               John Rylands Library Ethiopic 23
               <sup>Sup 1</sup>
@@ -161,7 +161,7 @@
       <division label="Verse"/>
     </divisions>
     <manuscripts>
-      <ms abbrev="p1" language="Ethiopic" show="yes">
+      <ms abbrev="p" language="Ethiopic" show="yes">
           <name>John Rylands Library Ethiopic 23</name>
       </ms>
     </manuscripts>
@@ -181,7 +181,7 @@
       <division label="Verse"/>
     </divisions>
     <manuscripts>
-      <ms abbrev="p1" language="Ethiopic" show="yes">
+      <ms abbrev="p" language="Ethiopic" show="yes">
           <name>John Rylands Library Ethiopic 23</name>
       </ms>
     </manuscripts>


### PR DESCRIPTION
Here's a proof of concept for the js parser. It is still snappier than the the current, but the current one is going a lot faster than it was when I was using it a few months ago. Perhaps you've optimized it, or perhaps there was something wrong when I was using it before. It took about 6 seconds to do anything, even just view variant readings.

On the 1 Enoch document there are manuscripts p1, p2, and p3, but in the text, variants are just marked as p. As you can see, I had to change p1 to just p to get this to work. I think I just don't understand the naming conventions.